### PR TITLE
Fix homebrew warnings

### DIFF
--- a/Casks/unfudged-staging.rb
+++ b/Casks/unfudged-staging.rb
@@ -10,7 +10,7 @@ cask "unfudged-staging" do
   conflicts_with cask: "unfudged"
 
   depends_on formula: "cyrusradfar/unf/unf-staging"
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "UNFUDGED.app"
 end

--- a/Casks/unfudged.rb
+++ b/Casks/unfudged.rb
@@ -8,7 +8,7 @@ cask "unfudged" do
   homepage "https://unfudged.io"
 
   depends_on formula: "cyrusradfar/unf/unf"
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "UNFUDGED.app"
 end

--- a/packaging/homebrew/unfudged-staging.rb
+++ b/packaging/homebrew/unfudged-staging.rb
@@ -10,7 +10,7 @@ cask "unfudged-staging" do
   conflicts_with cask: "unfudged"
 
   depends_on formula: "cyrusradfar/unf/unf-staging"
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "UNFUDGED.app"
 end

--- a/packaging/homebrew/unfudged.rb
+++ b/packaging/homebrew/unfudged.rb
@@ -8,7 +8,7 @@ cask "unfudged" do
   homepage "https://unfudged.io"
 
   depends_on formula: "cyrusradfar/unf/unf"
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "UNFUDGED.app"
 end


### PR DESCRIPTION
As per Homebrew documentation at https://docs.brew.sh/Formula-Cookbook: Top-level depends_on :macos marks a formula as macOS-only. Top-level depends_on macos: :sonoma marks a formula as macOS-only and declares the minimum compatible macOS release.

Currently Homebrew flags multiple warnings during `brew update` and `brew upgrade`:
```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the cyrusradfar/homebrew-unf tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/cyrusradfar/homebrew-unf/Casks/unfudged.rb:11

Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the cyrusradfar/homebrew-unf tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/cyrusradfar/homebrew-unf/Casks/unfudged.rb:11

Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the cyrusradfar/homebrew-unf tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/cyrusradfar/homebrew-unf/Casks/unfudged.rb:11

Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the cyrusradfar/homebrew-unf tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/cyrusradfar/homebrew-unf/Casks/unfudged.rb:11
```